### PR TITLE
admin 게시글/짧은 글 관리 구분 화면 추가

### DIFF
--- a/src/app/(admin)/admin/page.tsx
+++ b/src/app/(admin)/admin/page.tsx
@@ -1,40 +1,26 @@
-import {
-  Article,
-  getAdminArticlesList,
-} from '@/app/(admin)/admin/lib/articles';
 import Link from 'next/link';
-import CreateArticleForm from './components/CreateArticleForm';
-import { getTagsList, Tag } from './lib/tags';
 
-export default async function AdminPage() {
-  const [articles, tags]: [Omit<Article, 'content'>[], Tag[]] =
-    await Promise.all([getAdminArticlesList(), getTagsList()]);
-
+export default function AdminPage() {
   return (
-    <div className="bg-white-500 h-full">
-      <h1 className="text-2xl font-bold text-center py-4">관리자 페이지</h1>
-      <CreateArticleForm tags={tags} />
-
-      <div className="m-3">
-        <h2 className="text-xl font-bold  py-4">작성된 글 목록</h2>
-        {articles && articles.length > 0 ? (
-          <ul>
-            {articles.map((article) => (
-              <li key={article.id}>
-                <Link href={`/admin/posts/edit/${article.id.toString()}`}>
-                  {article.title}
-                </Link>
-                <span>
-                  {' '}
-                  - {new Date(article.created_at).toLocaleDateString()}
-                </span>
-              </li>
-            ))}
-          </ul>
-        ) : (
-          <p>작성된 글이 없습니다.</p>
-        )}
-      </div>
-    </div>
+    <nav className="bg-white-500 h-screen p-4">
+      <ol className="flex flex-col gap-4">
+        <li>
+          <Link
+            href="/admin/posts"
+            className="hover:bg-gray-100 p-2 rounded-md"
+          >
+            게시글 관리
+          </Link>
+        </li>
+        <li>
+          <Link
+            href="/admin/short_posts"
+            className="hover:bg-gray-100 p-2 rounded-md"
+          >
+            짧은 글 관리
+          </Link>
+        </li>
+      </ol>
+    </nav>
   );
 }

--- a/src/app/(admin)/admin/posts/page.tsx
+++ b/src/app/(admin)/admin/posts/page.tsx
@@ -1,0 +1,40 @@
+import {
+  Article,
+  getAdminArticlesList,
+} from '@/app/(admin)/admin/lib/articles';
+import Link from 'next/link';
+import CreateArticleForm from '../components/CreateArticleForm';
+import { getTagsList, Tag } from '../lib/tags';
+
+export default async function AdminPostsPage() {
+  const [articles, tags]: [Omit<Article, 'content'>[], Tag[]] =
+    await Promise.all([getAdminArticlesList(), getTagsList()]);
+
+  return (
+    <div className="bg-white-500 h-full">
+      <h1 className="text-2xl font-bold text-center py-4">관리자 페이지</h1>
+      <CreateArticleForm tags={tags} />
+
+      <div className="m-3">
+        <h2 className="text-xl font-bold  py-4">작성된 글 목록</h2>
+        {articles && articles.length > 0 ? (
+          <ul>
+            {articles.map((article) => (
+              <li key={article.id}>
+                <Link href={`/admin/posts/edit/${article.id.toString()}`}>
+                  {article.title}
+                </Link>
+                <span>
+                  {' '}
+                  - {new Date(article.created_at).toLocaleDateString()}
+                </span>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p>작성된 글이 없습니다.</p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(admin)/admin/short_posts/page.tsx
+++ b/src/app/(admin)/admin/short_posts/page.tsx
@@ -1,0 +1,17 @@
+import Link from 'next/link';
+
+export default async function ShortPostsPage() {
+  return (
+    <div className="p-6">
+      <div className="flex justify-between items-center mb-6">
+        <h1 className="text-2xl font-bold">짧은 글 관리</h1>
+        <Link
+          href="/admin/short_posts/create"
+          className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+        >
+          새 짧은 글 작성
+        </Link>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
<img width="453" alt="image" src="https://github.com/user-attachments/assets/2c540e6e-c01a-4fa4-a30f-56c157cd11f8" />

/admin 으로 접근할때 첫 화면으로 게시글/짧은 글 관리로 나오게 설정했습니다.
게시글 - /admin/posts
짧은글 - /admin/short_posts 
